### PR TITLE
Fix event handler leak

### DIFF
--- a/api.js
+++ b/api.js
@@ -23,7 +23,7 @@ var Api = function(client, session) {
   };
 
   var onClose = function() {
-    that.removeListener('message', onMessage);
+    that.reqres.removeListener('message', onMessage);
     that.stop();
   };
 


### PR DESCRIPTION
I noticed this while reading the code and have not tested it, but I think the wrong EventEmitter object was getting the `removeListener` call.
