### PR TITLE
Guard against empty status response

### DIFF
--- a/api.js
+++ b/api.js
@@ -59,9 +59,10 @@ Api.prototype.updateStatus = function(cb) {
   var that = this;
   cb = cb || noop;
   this.getStatus(function(err, status) {
-    if ( ! status) return;
-    that.emit(status.playerState.toLowerCase(), status);
-    that.emit('status', status);
+    if (status) {
+      that.emit(status.playerState.toLowerCase(), status);
+      that.emit('status', status);
+    }
     cb(err, status);
   });
 };

--- a/api.js
+++ b/api.js
@@ -59,7 +59,7 @@ Api.prototype.updateStatus = function(cb) {
   var that = this;
   cb = cb || noop;
   this.getStatus(function(err, status) {
-    if (err) return;
+    if ( ! status) return;
     that.emit(status.playerState.toLowerCase(), status);
     that.emit('status', status);
     cb(err, status);


### PR DESCRIPTION
I came across an issue where Chromecast responds to a `GET_STATUS` request with an empty status:

```
castv2 recv message: protocolVersion=0 sourceId=web-17 destinationId=client-207617 namespace=urn:x-cast:com.google.cast.media data={"type":"MEDIA_STATUS","status":[],"requestId":1}
```

I'm not sure when exactly this can happen, but for me it happened after casting songza.com and then closing the tab (which causes the Chromecast to stop playing, but the receiver app is still running).

This change guards against this case by checking for the existence of a non-falsey status object.